### PR TITLE
Allow Embedded to be hidden and toggled

### DIFF
--- a/documentation/EmbeddedConversation.md
+++ b/documentation/EmbeddedConversation.md
@@ -67,6 +67,7 @@ You may also use the `import()` method.
 
 Then, create an instance of the TextUsEmbeddedConversation() class. Ensure to pass in the `id` used by your container element. Afterwards, you can render the instance with the `render()` method.
 
+The iframe will render by default. If you want to hide it until prompted, set `initiallyHidden` to true in the options prop. In addition to `.render()`, you can use `.hide()`, `.show()` or `.toggle()` to control whether the iframe is visible.
 ```html
 <script defer>
   ...
@@ -75,6 +76,7 @@ Then, create an instance of the TextUsEmbeddedConversation() class. Ensure to pa
   const textUsEmbeddedConversation = new TextUsEmbeddedConversation('iframe-here', {
     channelPartner: 'CompanyName',
     height: '800px',
+    initiallyHidden: true,
     width: '800px',
     contact: {
       phoneNumber: '555-555-5555',
@@ -83,6 +85,15 @@ Then, create an instance of the TextUsEmbeddedConversation() class. Ensure to pa
 
   // Render the iframe.
   textUsEmbeddedConversation.render();
+
+  // Hides the iframe.
+  textUsEmbeddedConversation.hide();
+
+  // Unhides the iframe.
+  textUsEmbeddedConversation.show();
+
+  // Toggles the iframe.
+  textUsEmbeddedConversation.toggle();
 
   ...
 </script>

--- a/src/App/TextUsEmbeddedApp.ts
+++ b/src/App/TextUsEmbeddedApp.ts
@@ -42,13 +42,14 @@ export class TextUsEmbeddedApp {
 
       // Set iframe attributes.
       this.iframe.id = "embedded-app-iframe";
-      this.iframe.src = textUsUrl;
       this.iframe.width = width || String(container.clientWidth) + "px";
       this.iframe.height = height || String(container.clientHeight) + "px";
 
       // Hide iframe if initiallyHidden is true.
       if (this.props.initiallyHidden) {
         this.iframe.style.display = "none";
+      } else {
+        this.iframe.src = textUsUrl;
       }
 
       // Clear container.
@@ -66,6 +67,7 @@ export class TextUsEmbeddedApp {
    */
   show() {
     if (this.iframe) {
+      !this.iframe.src && (this.iframe.src = textUsUrl);
       this.iframe.style.display = "block";
     }
   }
@@ -84,8 +86,7 @@ export class TextUsEmbeddedApp {
    */
   toggle() {
     if (this.iframe) {
-      this.iframe.style.display =
-        this.iframe.style.display === "none" ? "block" : "none";
+      this.iframe.style.display === "none" ? this.show() : this.hide();
     }
   }
 

--- a/src/App/TextUsEmbeddedApp.ts
+++ b/src/App/TextUsEmbeddedApp.ts
@@ -15,7 +15,7 @@ export class TextUsEmbeddedApp {
   constructor(
     public containerId: string,
     public props: TextUsEmbeddedAppProps,
-  ) { }
+  ) {}
 
   /**
    * Render the embedded app iframe.
@@ -25,7 +25,7 @@ export class TextUsEmbeddedApp {
       const { channelPartner, height, width } = this.props;
 
       if (!channelPartner) {
-        throw new Error('No channel partner provided.');
+        throw new Error("No channel partner provided.");
       }
 
       // Create an iframe element.
@@ -35,22 +35,57 @@ export class TextUsEmbeddedApp {
       const container = document.querySelector(`#${this.containerId}`);
 
       if (!container) {
-        throw new Error(`Could not find container with id: ${this.containerId}`);
+        throw new Error(
+          `Could not find container with id: ${this.containerId}`,
+        );
       }
 
-      // Set iframe attributes. 
-      this.iframe.id = 'embedded-app-iframe';
+      // Set iframe attributes.
+      this.iframe.id = "embedded-app-iframe";
       this.iframe.src = textUsUrl;
-      this.iframe.width = width || String(container.clientWidth) + 'px';
-      this.iframe.height = height || String(container.clientHeight) + 'px';
+      this.iframe.width = width || String(container.clientWidth) + "px";
+      this.iframe.height = height || String(container.clientHeight) + "px";
+
+      // Hide iframe if initiallyHidden is true.
+      if (this.props.initiallyHidden) {
+        this.iframe.style.display = "none";
+      }
 
       // Clear container.
-      container.innerHTML = '';
+      container.innerHTML = "";
 
       // Append iframe to container.
       container.appendChild(this.iframe);
     } catch (err) {
       console.error(err);
+    }
+  }
+
+  /**
+   * Show the iframe.
+   */
+  show() {
+    if (this.iframe) {
+      this.iframe.style.display = "block";
+    }
+  }
+
+  /**
+   * Hide the iframe.
+   */
+  hide() {
+    if (this.iframe) {
+      this.iframe.style.display = "none";
+    }
+  }
+
+  /**
+   * Toggle the iframe visibility.
+   */
+  toggle() {
+    if (this.iframe) {
+      this.iframe.style.display =
+        this.iframe.style.display === "none" ? "block" : "none";
     }
   }
 
@@ -63,9 +98,12 @@ export class TextUsEmbeddedApp {
       return;
     }
 
-    this.iframe.contentWindow.postMessage({
-      type: 'findNumbersResponse',
-      payload: contacts,
-    }, '*');
+    this.iframe.contentWindow.postMessage(
+      {
+        type: "findNumbersResponse",
+        payload: contacts,
+      },
+      "*",
+    );
   }
 }

--- a/src/Conversation/Conversation.ts
+++ b/src/Conversation/Conversation.ts
@@ -61,13 +61,17 @@ export class TextUsEmbeddedConversation {
 
       // Set iframe attributes.
       this.iframe.id = "embedded-conversation-iframe";
-      this.iframe.src = getConversationUrl(contact.phoneNumber, channelPartner);
       this.iframe.width = width || String(container.clientWidth) + "px";
       this.iframe.height = height || String(container.clientHeight) + "px";
 
       // Hide iframe if initiallyHidden is true.
       if (this.props.initiallyHidden) {
         this.iframe.style.display = "none";
+      } else {
+        this.iframe.src = getConversationUrl(
+          contact.phoneNumber,
+          channelPartner,
+        );
       }
 
       // Clear container.
@@ -85,6 +89,11 @@ export class TextUsEmbeddedConversation {
    */
   show() {
     if (this.iframe) {
+      !this.iframe.src &&
+        (this.iframe.src = getConversationUrl(
+          this.props.contact.phoneNumber,
+          this.props.channelPartner,
+        ));
       this.iframe.style.display = "block";
     }
   }
@@ -103,8 +112,7 @@ export class TextUsEmbeddedConversation {
    */
   toggle() {
     if (this.iframe) {
-      this.iframe.style.display =
-        this.iframe.style.display === "none" ? "block" : "none";
+      this.iframe.style.display === "none" ? this.show() : this.hide();
     }
   }
 

--- a/src/Conversation/Conversation.ts
+++ b/src/Conversation/Conversation.ts
@@ -9,8 +9,13 @@ const textUsUrl = "http://localhost:3000";
  * @param channelPartner Channel partner name.
  * @returns URL for iframe.
  */
-export function getConversationUrl(phoneNumber: string, channelPartner: string): string {
-  return `${textUsUrl}/c/embedded?phoneNumber=${encodeURIComponent(phoneNumber)}&channelPartner=${channelPartner}`;
+export function getConversationUrl(
+  phoneNumber: string,
+  channelPartner: string,
+): string {
+  return `${textUsUrl}/c/embedded?phoneNumber=${encodeURIComponent(
+    phoneNumber,
+  )}&channelPartner=${channelPartner}`;
 }
 
 export class TextUsEmbeddedConversation {
@@ -25,7 +30,7 @@ export class TextUsEmbeddedConversation {
   constructor(
     public containerId: string,
     public props: TextUsEmbeddedConversationOptionProps,
-  ) { }
+  ) {}
 
   /**
    * Render the embedded conversation iframe.
@@ -35,11 +40,11 @@ export class TextUsEmbeddedConversation {
       const { channelPartner, height, width, contact } = this.props;
 
       if (!channelPartner) {
-        throw new Error('No channel partner provided.');
+        throw new Error("No channel partner provided.");
       }
 
       if (!contact) {
-        throw new Error('No contact provided.');
+        throw new Error("No contact provided.");
       }
 
       // Create an iframe element.
@@ -49,17 +54,24 @@ export class TextUsEmbeddedConversation {
       const container = document.querySelector(`#${this.containerId}`);
 
       if (!container) {
-        throw new Error(`Could not find container with id: ${this.containerId}`);
+        throw new Error(
+          `Could not find container with id: ${this.containerId}`,
+        );
       }
 
-      // Set iframe attributes. 
-      this.iframe.id = 'embedded-conversation-iframe';
+      // Set iframe attributes.
+      this.iframe.id = "embedded-conversation-iframe";
       this.iframe.src = getConversationUrl(contact.phoneNumber, channelPartner);
-      this.iframe.width = width || String(container.clientWidth) + 'px';
-      this.iframe.height = height || String(container.clientHeight) + 'px';
+      this.iframe.width = width || String(container.clientWidth) + "px";
+      this.iframe.height = height || String(container.clientHeight) + "px";
+
+      // Hide iframe if initiallyHidden is true.
+      if (this.props.initiallyHidden) {
+        this.iframe.style.display = "none";
+      }
 
       // Clear container.
-      container.innerHTML = '';
+      container.innerHTML = "";
 
       // Append iframe to container.
       container.appendChild(this.iframe);
@@ -69,11 +81,42 @@ export class TextUsEmbeddedConversation {
   }
 
   /**
+   * Show the iframe.
+   */
+  show() {
+    if (this.iframe) {
+      this.iframe.style.display = "block";
+    }
+  }
+
+  /**
+   * Hide the iframe.
+   */
+  hide() {
+    if (this.iframe) {
+      this.iframe.style.display = "none";
+    }
+  }
+
+  /**
+   * Toggle the iframe visibility.
+   */
+  toggle() {
+    if (this.iframe) {
+      this.iframe.style.display =
+        this.iframe.style.display === "none" ? "block" : "none";
+    }
+  }
+
+  /**
    * Update the contact for the embedded conversation and re-render the iframe.
    * @param contact Contact to set for the embedded conversation.
    */
-  setContact(contact: TextUsEmbeddedConversationOptionProps['contact']) {
+  setContact(contact: TextUsEmbeddedConversationOptionProps["contact"]) {
     this.props.contact = contact;
-    this.iframe!.src = getConversationUrl(contact.phoneNumber, this.props.channelPartner);
+    this.iframe!.src = getConversationUrl(
+      contact.phoneNumber,
+      this.props.channelPartner,
+    );
   }
 }

--- a/src/Messenger/Messenger.ts
+++ b/src/Messenger/Messenger.ts
@@ -1,3 +1,0 @@
-export function TextUsEmbeddedMessenger() {
-  return 'Hello from Messenger';
-}

--- a/src/Messenger/index.ts
+++ b/src/Messenger/index.ts
@@ -1,3 +1,0 @@
-export {
-  TextUsEmbeddedMessenger,
-} from './Messenger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export * from './models';
-export * from './Conversation';
-export * from './Messenger';
-export * from './App';
+export * from "./models";
+export * from "./Conversation";
+export * from "./App";

--- a/src/models/TextUsEmbeddedAppProps.ts
+++ b/src/models/TextUsEmbeddedAppProps.ts
@@ -1,5 +1,6 @@
 export interface TextUsEmbeddedAppProps {
   channelPartner: string;
+  initiallyHidden?: boolean;
   height?: string;
   width?: string;
 }

--- a/src/models/TextUsEmbeddedConversationOptionProps.ts
+++ b/src/models/TextUsEmbeddedConversationOptionProps.ts
@@ -1,6 +1,7 @@
 export interface TextUsEmbeddedConversationOptionProps {
   channelPartner: string;
   height?: string;
+  initiallyHidden?: boolean;
   width?: string;
   contact: {
     phoneNumber: string;


### PR DESCRIPTION
## Description
End users needed an option to have our embedded solutions hidden until prompted. Given that, they would also need a way to unhide it. This PR adds an option to the `props` of `TextUsEmbeddedMessenger` and `TextUsEmbeddedApp` for `initiallyHidden`, which defaults to falsy but can be set to `true`. If `true`, the iframe will be hidden until a user takes an action to show it.

Then, I added `.toggle()`, `.hide()`, and `.show()` to give users control over the display functionality.

I also updated the user-facing documentation to reflect these changes.

The expected flow is:
 - If a user does not have `initiallyHidden` set or has set it to `false`, the iframe renders on initial load
 - If a user has `initiallyHidden` set to `true`, the iframe does not render on load AND no Tesseract-related fetches fire
   - When the iframe is toggled on for the first time, Tesseract goes through the boot and auth processes and all initial fetches
   - Once the iframe has been toggled on for the first time, subsequent toggles do not fire additional fetches; the iframe content does not reload or refresh, but remains on the screen the user was last on

## Jira Ticket

[BLUE-64] 

## Screenshots
https://www.loom.com/share/ad4d0abaab3d42fd849d08bb4efaa54c?sid=fe7bcbbf-5d20-466d-b968-d742dc316fc0

## Test Instructions
1. Go through the READMEs of `Embedded-Messenger` and `Embedded-Tesseract-Playground` to get them set up and linked. Boot a server for `tesseract` and `Embedded-Tesseract-Playground` (`npm run serve:react`).
2. Open the code for `Embedded-Tesseract-Playground` and add the following button to Line 133ish in `page.tsx`:
```
          <button
            onClick={() => {
              embeddedConversation01.current.toggle();
            }}
          >
            Toggle
          </button>
```
3. On Line 41 of `page.tsx`, add the `initiallyHidden` prop:
```
  // Using the TextUsEmbeddedConversation class to create an iframe.
  const embeddedConversation01 = useRef(
    new TextUsEmbeddedConversation("iframe-here", {
      channelPartner: "TalentReef",
      initiallyHidden: true, <----- this little guy right here
      height: "400px",
      width: "800px",
      contact: {
        phoneNumber: defaultPhoneNumber,
      },
    }),
  );
```
4. Refresh the browser tab to `localhost:8080`; you should see the button, and the middle iframe should be hidden
5. Check your devtools Network tab and be sure no Tesseract-related fetches have fired
6. Click the toggle button; the iframe should show up with the associated data fetches
7. Click around in the iframe, navigating to a different screen
8. Toggle the iframe; it should hide
9. Toggle it again; when it displays, it should still be on the screen you last visited

[BLUE-64]: https://textus.atlassian.net/browse/BLUE-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ